### PR TITLE
Prevent done() being called multiple times

### DIFF
--- a/tasks/markedman.js
+++ b/tasks/markedman.js
@@ -21,13 +21,12 @@ module.exports = function(grunt) {
     });
 
     var done = this.async();
-    var jobs = { errored: 0, pending: 0 };
+    var jobs = { errored: 0, pending: this.files.length };
 
     this.files.forEach(function(file) {
 
       var markedMan = require('marked-man');
 
-      jobs.pending++;
       markedMan(grunt.file.read(file.src), {
         version: options.version,
         section: options.section,
@@ -38,13 +37,12 @@ module.exports = function(grunt) {
         if (err instanceof Error) {
           jobs.errored++;
           grunt.log.error('File "' + file.dest + '"could NOT be created.');
-          done(err);
         } else {
           grunt.file.write(file.dest, result);
           grunt.log.writeln('File "' + file.dest + '" created.');
-          if (jobs.errored === 0 && jobs.pending === 0) {
-            done();
-          }
+        }
+        if (jobs.pending === 0) {
+          done(jobs.errored === 0);
         }
       });
     });


### PR DESCRIPTION
The `done()` method is being called multiple times, which creates problems for subsequent tasks. Two issues:
1. `jobs.pending === 0` is always true. I'm not certain, but I suspect `markedMan()` is running the callback synchronously, so `jobs.pending--` runs before the next file's `jobs.pending++` (so it goes 0, 1, 0, 1, ... instead of 0, 1, 2, ..., 2, 1, 0). Instead I've initialised `jobs.pending` to the number of files at the start.
2. If there's more than one error, `done(err)` is called every time. I've modified it to always call `done()` once at the end. (Also it now calls `done(false)`, as in the [Grunt docs](http://gruntjs.com/creating-tasks), rather than `done(err)` - not sure if that's strictly necessary.)
